### PR TITLE
Update k8s.gcr.io to registry.k8s.io on the EKS autoscalers

### DIFF
--- a/fluxcd/clusters/staging/aws-system/aws-cluster-autoscaler-autodiscover.yaml
+++ b/fluxcd/clusters/staging/aws-system/aws-cluster-autoscaler-autodiscover.yaml
@@ -149,7 +149,7 @@ spec:
         fsGroup: 65534
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.2
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.2
           name: cluster-autoscaler
           resources:
             limits:


### PR DESCRIPTION
Due to https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/
I'm updating the image used by the autoscaler in this repository. This should not have any affection since it is the exact same image (check sha256)


```
docker pull registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.2
v1.22.2: Pulling from autoscaling/cluster-autoscaler
e8614d09b7be: Pull complete 
285c87824ef2: Pull complete 
Digest: sha256:23d18aa556222f62a2d6baefa0de8757a5fe4ac3f218ba685106429333aea820
Status: Downloaded newer image for registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.2
registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.2
```


```
docker pull k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.2
v1.22.2: Pulling from autoscaling/cluster-autoscaler
Digest: sha256:23d18aa556222f62a2d6baefa0de8757a5fe4ac3f218ba685106429333aea820
Status: Downloaded newer image for k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.2
k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.2
```
